### PR TITLE
Fix seekBlock and load model file directly via plt binary

### DIFF
--- a/table/sstable/builder.go
+++ b/table/sstable/builder.go
@@ -168,7 +168,7 @@ func NewTableBuilder(f *os.File, limiter *rate.Limiter, level int, opt options.T
 		level: level,
 		bufSize: opt.WriteBufferSize,
 	}
-	modFile, err := y.OpenTruncFile(ModelFilename(b.file.Name(), level), false)
+	modFile, err := y.OpenTruncFile(ModelFilename(b.file.Name()), false)
 	if err != nil {
 		panic(err)
 	}
@@ -202,7 +202,7 @@ func (b *Builder) Reset(f *os.File) {
 	b.resetBuffers()
 	b.w.Reset(f)
 
-	modFile, err := y.OpenTruncFile(ModelFilename(b.file.Name(), b.level), false)
+	modFile, err := y.OpenTruncFile(ModelFilename(b.file.Name()), false)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
I made some changes and I tested locally it seems working and the plr can be used for searching the block.

Now you only need to copy that `plt` binary in your `tbadger` repo and run the test script with it.

You can test the changes here with this update: https://github.com/spongedu/tbadger/pull/1